### PR TITLE
Put output binary in $GOPATH/bin/keywhizfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ export GO15VENDOREXPERIMENT = 1
 
 # Build
 build: depends git-fsck
-	go build keywhizfs/main.go
+	mkdir -p ${GOPATH}/bin
+	go build -o ${GOPATH}/bin/keywhizfs keywhizfs/main.go
 
 # Dependencies
 depends:


### PR DESCRIPTION
This matches where "go get github.com/square/keywhiz-fs/keywhizfs" puts it,
and having them the same is nice.  Also, that folder is in my $PATH, which
is useful for making it easy to run.