### PR TITLE
Dummy statfs implementation

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -182,6 +182,13 @@ func (kwfs KeywhizFs) Unlink(name string, context *fuse.Context) fuse.Status {
 	return fuse.EACCES
 }
 
+// StatFs is a FUSE function called to provide information about the filesystem
+// We return zeros, which makes "df" think this is a dummy fs, which it is.
+func (kwfs KeywhizFs) StatFs(name string) *fuse.StatfsOut {
+	kwfs.Debugf("StatFs called with '%v'", name)
+	return &fuse.StatfsOut{}
+}
+
 // secretsDirListing produces directory entries containing all secret files. Extra entries passed
 // to this function are included.
 func (kwfs KeywhizFs) secretsDirListing(extraEntries ...fuse.DirEntry) []fuse.DirEntry {


### PR DESCRIPTION
This is enough to make "df" happy:  It no longer complains about unimplemented functions.
df does, however, decide this is a Dummy filesystem and you need to pass "df -a" to see it listed.
```
 $ > df -a
Filesystem           1K-blocks      Used Available Use% Mounted on
keywhiz-fs                   0         0         0    - /data/app/secrets
```

There's no tests.  I'm not sure how we could test this, and whether we'd want to return non-dummy values.  It's plausible we could compute the size of all secrets and return that, but I'd also not want to return the FS as 100% full -- I bet people have monitoring for full filesystems and that would be a nuisance.  All zeros seems easiest, cheapest, and suitable enough.

Note: On OS X, go-fuse does this for you. See opcode.go's doStatFs: https://github.com/hanwen/go-fuse/blob/master/fuse/opcode.go#L352-L357