### PR TITLE
Flatten package structure and simplify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,7 @@ eclipsebin
 *.iml
 *.ipr
 *.iws
+*.out
 .DS_Store
 vendor/
+keywhiz-fs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,29 @@
 language: go
 
-sudo: true
+sudo: required
+dist: trusty
 
 env:
 - GO15VENDOREXPERIMENT=1
 
-matrix:
-  allow_failures:
-    - go: tip
-
 go:
-- 1.5
-- tip
+- 1.6
 
 before_script:
 - go vet
 
 before_install:
 - go get github.com/Masterminds/glide
-- make depends
+- go get github.com/axw/gocov/gocov
+- go get github.com/mattn/goveralls
+- go get golang.org/x/tools/cmd/cover
+- sudo apt-get install fuse
 
 install:
 - make build
-- sudo apt-get install fuse-utils
-# This is to properly get fusermount on travis
 
 script:
-- go test -v .
+- make test
+
+after_success:
+- $HOME/gopath/bin/goveralls -coverprofile coverage.out -service=travis-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN useradd -ms /bin/false keywhiz
 COPY . /go/src/github.com/square/keywhiz-fs
 
 # Install keywhizfs
-RUN go get github.com/square/keywhiz-fs/keywhizfs
+RUN go get github.com/square/keywhiz-fs
 
 # Allows keywhiz-fs to expose its filesystems to other users besides the owner of the process
 RUN echo "user_allow_other" >> /etc/fuse.conf

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 export GO15VENDOREXPERIMENT = 1
 
 # Build
-build: depends git-fsck
-	go build keywhizfs/main.go
+build: depends
+	go build
 
 # Dependencies
 depends:
@@ -11,19 +11,8 @@ depends:
 update-depends:
 	glide -q update
 
-# Check integrity of dependencies
-git-fsck:
-	@for repo in `find vendor -name .git`; do \
-		echo "git --git-dir=$$repo fsck --full --strict --no-dangling"; \
-		git --git-dir=$$repo fsck --full --strict --no-dangling || exit 1; \
-	done
-
 # Run all tests
 test: unit
 
-# Run unit tests
-pre-unit:
-	@echo "*** Running unit tests ***"
-
-unit: pre-unit
-	go test -v
+unit:
+	go test -v -coverprofile coverage.out

--- a/cache.go
+++ b/cache.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs
+package main
 
 import (
 	"time"

--- a/client.go
+++ b/client.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs
+package main
 
 import (
 	"crypto/tls"

--- a/client_test.go
+++ b/client_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs_test
+package main
 
 import (
 	"fmt"
@@ -23,13 +23,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/square/keywhiz-fs"
 	"github.com/stretchr/testify/assert"
 )
 
 var (
 	clientFile = "fixtures/client.pem"
-	caFile     = "fixtures/localhost.crt"
+	testCaFile = "fixtures/localhost.crt"
 )
 
 func TestClientCallsServer(t *testing.T) {
@@ -45,12 +44,12 @@ func TestClientCallsServer(t *testing.T) {
 			w.WriteHeader(404)
 		}
 	}))
-	server.TLS = testCerts(caFile)
+	server.TLS = testCerts(testCaFile)
 	server.StartTLS()
 	defer server.Close()
 
 	serverURL, _ := url.Parse(server.URL)
-	client := keywhizfs.NewClient(clientFile, clientFile, caFile, serverURL, time.Second, logConfig, false)
+	client := NewClient(clientFile, clientFile, testCaFile, serverURL, time.Second, logConfig, false)
 
 	secrets, ok := client.SecretList()
 	assert.True(ok)

--- a/fs.go
+++ b/fs.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs
+package main
 
 import (
 	"fmt"

--- a/glide.lock
+++ b/glide.lock
@@ -1,25 +1,32 @@
 hash: 3fb21e0e2d4062d0de91b07fa04212558ddb5b38e3511ee814ddb9e38bbe6907
-updated: 2016-02-24T15:12:16.567059963-08:00
+updated: 2016-03-06T19:30:29.304964851-08:00
 imports:
+- name: github.com/davecgh/go-spew
+  version: 2df174808ee097f90d259e432cc04442cf60be21
+  subpackages:
+  - spew
 - name: github.com/hanwen/go-fuse
   version: 9ecf4dc59b43a0870562e61d7d9fc7d40e263ada
   subpackages:
   - fuse
   - fuse/nodefs
   - fuse/pathfs
-  - splice
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib
 - name: github.com/rcrowley/go-metrics
   version: 51425a2415d21afadfd55cd93432c0bc69e9598d
 - name: github.com/square/go-sq-metrics
   version: fee8afed8130469572261b06eb06a54eab2bb219
-- name: github.com/square/keywhiz-fs
-  version: 3f2dd68f01f03b7ae627549b1d889696e0b1b5ff
-  subpackages:
-  - log
+- name: github.com/stretchr/objx
+  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 1f4a1643a57e798696635ea4c126e9127adb7d3c
   subpackages:
   - assert
+  - http
+  - mock
 - name: golang.org/x/sys
   version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
   subpackages:

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/hanwen/go-fuse/fuse/nodefs"
 	"github.com/rcrowley/go-metrics"
 	"github.com/square/go-sq-metrics"
-	"github.com/square/keywhiz-fs"
 	klog "github.com/square/keywhiz-fs/log"
 	"golang.org/x/sys/unix"
 )
@@ -37,8 +36,8 @@ var (
 	certFile       = flag.String("cert", "", "PEM-encoded certificate file")
 	keyFile        = flag.String("key", "client.key", "PEM-encoded private key file")
 	caFile         = flag.String("ca", "cacert.crt", "PEM-encoded CA certificates file")
-	user           = flag.String("asuser", "keywhiz", "Default user to own files")
-	group          = flag.String("group", "keywhiz", "Default group to own files")
+	asuser         = flag.String("asuser", "keywhiz", "Default user to own files")
+	asgroup        = flag.String("group", "keywhiz", "Default group to own files")
 	ping           = flag.Bool("ping", false, "Enable startup ping to server")
 	debug          = flag.Bool("debug", false, "Enable debugging output")
 	timeoutSeconds = flag.Uint("timeout", 20, "Timeout for communication with server")
@@ -86,12 +85,12 @@ func main() {
 	freshThreshold := 200 * time.Millisecond
 	backendDeadline := 500 * time.Millisecond
 	maxWait := clientTimeout + backendDeadline
-	timeouts := keywhizfs.Timeouts{freshThreshold, backendDeadline, maxWait}
+	timeouts := Timeouts{freshThreshold, backendDeadline, maxWait}
 
-	client := keywhizfs.NewClient(*certFile, *keyFile, *caFile, serverURL, clientTimeout, logConfig, *ping)
+	client := NewClient(*certFile, *keyFile, *caFile, serverURL, clientTimeout, logConfig, *ping)
 
-	ownership := keywhizfs.NewOwnership(*user, *group)
-	kwfs, root, err := keywhizfs.NewKeywhizFs(&client, ownership, timeouts, logConfig)
+	ownership := NewOwnership(*asuser, *asgroup)
+	kwfs, root, err := NewKeywhizFs(&client, ownership, timeouts, logConfig)
 	if err != nil {
 		log.Fatalf("KeywhizFs init fail: %v\n", err)
 	}

--- a/ownership.go
+++ b/ownership.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs
+package main
 
 import (
 	"log"

--- a/secret.go
+++ b/secret.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs
+package main
 
 import (
 	"encoding/base64"

--- a/secret_test.go
+++ b/secret_test.go
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs_test
+package main
 
 import (
 	"testing"
 	"time"
 
-	"github.com/square/keywhiz-fs"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
@@ -26,7 +25,7 @@ import (
 func TestDeserializeSecret(t *testing.T) {
 	assert := assert.New(t)
 
-	s, err := keywhizfs.ParseSecret(fixture("secret.json"))
+	s, err := ParseSecret(fixture("secret.json"))
 	assert.NoError(err)
 	assert.Equal("Nobody_PgPass", s.Name)
 	assert.EqualValues(6, s.Length)
@@ -43,7 +42,7 @@ func TestDeserializeSecret(t *testing.T) {
 func TestDeserializeSecretWithoutBase64Padding(t *testing.T) {
 	assert := assert.New(t)
 
-	s, err := keywhizfs.ParseSecret(fixture("secretWithoutBase64Padding.json"))
+	s, err := ParseSecret(fixture("secretWithoutBase64Padding.json"))
 	assert.NoError(err)
 	assert.Equal("NonexistentOwner_Pass", s.Name)
 	assert.EqualValues("12345", s.Content)
@@ -54,7 +53,7 @@ func TestDeserializeSecretList(t *testing.T) {
 
 	fixtures := []string{"secrets.json", "secretsWithoutContent.json"}
 	for _, f := range fixtures {
-		secrets, err := keywhizfs.ParseSecretList(fixture(f))
+		secrets, err := ParseSecretList(fixture(f))
 		assert.NoError(err)
 		assert.Len(secrets, 2)
 	}
@@ -64,12 +63,12 @@ func TestSecretModeValue(t *testing.T) {
 	assert := assert.New(t)
 
 	cases := []struct {
-		secret keywhizfs.Secret
+		secret Secret
 		mode   uint32
 	}{
-		{keywhizfs.Secret{Mode: "0440"}, 288},
-		{keywhizfs.Secret{Mode: "0400"}, 256},
-		{keywhizfs.Secret{}, 288},
+		{Secret{Mode: "0440"}, 288},
+		{Secret{Mode: "0400"}, 256},
+		{Secret{}, 288},
 	}
 	for _, c := range cases {
 		assert.Equal(c.mode|unix.S_IFREG, c.secret.ModeValue())

--- a/secretmap.go
+++ b/secretmap.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs
+package main
 
 import (
 	"sync"

--- a/secretmap_test.go
+++ b/secretmap_test.go
@@ -12,22 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs_test
+package main
 
 import (
 	"testing"
 
-	"github.com/square/keywhiz-fs"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestSecretMapOperations(t *testing.T) {
 	assert := assert.New(t)
 
-	s, err := keywhizfs.ParseSecret(fixture("secret.json"))
+	s, err := ParseSecret(fixture("secret.json"))
 	assert.NoError(err)
 
-	secretMap := keywhizfs.NewSecretMap()
+	secretMap := NewSecretMap()
 	assert.Equal(0, secretMap.Len())
 	assert.Empty(secretMap.Values())
 
@@ -45,14 +44,14 @@ func TestSecretMapOperations(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(*s, lookup.Secret)
 
-	put := secretMap.PutIfAbsent("foo", keywhizfs.Secret{})
+	put := secretMap.PutIfAbsent("foo", Secret{})
 	assert.False(put)
 
 	lookup, ok = secretMap.Get("foo")
 	assert.True(ok)
 	assert.Equal(*s, lookup.Secret)
 
-	secretMap.Put("foo", keywhizfs.Secret{})
+	secretMap.Put("foo", Secret{})
 
 	lookup, ok = secretMap.Get("foo")
 	assert.True(ok)
@@ -62,13 +61,13 @@ func TestSecretMapOperations(t *testing.T) {
 func TestSecretMapOverwrite(t *testing.T) {
 	assert := assert.New(t)
 
-	s, err := keywhizfs.ParseSecret(fixture("secret.json"))
+	s, err := ParseSecret(fixture("secret.json"))
 	assert.NoError(err)
 
-	secretMap := keywhizfs.NewSecretMap()
-	secretMap.Put("foo", keywhizfs.Secret{})
+	secretMap := NewSecretMap()
+	secretMap.Put("foo", Secret{})
 
-	newMap := keywhizfs.NewSecretMap()
+	newMap := NewSecretMap()
 	newMap.Put("bar", *s)
 	secretMap.Overwrite(newMap)
 
@@ -81,14 +80,14 @@ func TestSecretMapOverwrite(t *testing.T) {
 func TestSecretMapTimestamp(t *testing.T) {
 	assert := assert.New(t)
 
-	secretMap := keywhizfs.NewSecretMap()
-	secretMap.Put("foo", keywhizfs.Secret{})
+	secretMap := NewSecretMap()
+	secretMap.Put("foo", Secret{})
 
 	val, ok := secretMap.Get("foo")
 	assert.True(ok)
 	earlierTime := val.Time
 
-	secretMap.Put("foo", keywhizfs.Secret{})
+	secretMap.Put("foo", Secret{})
 	val, ok = secretMap.Get("foo")
 	assert.True(ok)
 	assert.True(val.Time.After(earlierTime))

--- a/util_test.go
+++ b/util_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keywhizfs_test
+package main
 
 import (
 	"crypto/tls"


### PR DESCRIPTION
r: @alokmenghrajani @mcpherrinm 
Flatten package structure and simplify build. In particular, this also makes a change to start collecting coverage information for unit tests. 

Coverage info here: https://coveralls.io/github/square/keywhiz-fs