### PR TITLE
Catch signals in a loop

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,7 +114,10 @@ func main() {
 	go func() {
 		sig := <-c
 		logger.Warnf("Got signal %s, unmounting", sig)
-		server.Unmount()
+		err := server.Unmount()
+		if err != nil {
+			logger.Warnf("Error while unmounting: %v", err)
+		}
 	}()
 
 	// Setup metrics
@@ -134,6 +137,7 @@ func main() {
 	}
 
 	server.Serve()
+	logger.Infof("Exiting")
 }
 
 // Locks memory, preventing memory from being written to disk as swap

--- a/main.go
+++ b/main.go
@@ -112,11 +112,13 @@ func main() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt)
 	go func() {
-		sig := <-c
-		logger.Warnf("Got signal %s, unmounting", sig)
-		err := server.Unmount()
-		if err != nil {
-			logger.Warnf("Error while unmounting: %v", err)
+		for {
+			sig := <-c
+			logger.Warnf("Got signal %s, unmounting", sig)
+			err := server.Unmount()
+			if err != nil {
+				logger.Warnf("Error while unmounting: %v", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
This supersedes my old PR to exit after unmounting: I think this is a better option.  We keep serving the FS if we can't exit -- eventually we should be able to exit, but there's no reason to die and leave the transport endpoint disconnected.