### PR TITLE
Add .json/metrics file to kwfs for local metrics access

### DIFF
--- a/fs_test.go
+++ b/fs_test.go
@@ -46,7 +46,7 @@ func (suite *FsTestSuite) SetupTest() {
 	timeouts := Timeouts{0, 10 * time.Millisecond, 20 * time.Millisecond}
 	client := NewClient(clientFile, clientFile, testCaFile, suite.url, timeouts.MaxWait, logConfig)
 	ownership := Ownership{Uid: _SomeUID, Gid: _SomeUID}
-	kwfs, _, _ := NewKeywhizFs(&client, ownership, timeouts, logConfig)
+	kwfs, _, _ := NewKeywhizFs(&client, ownership, timeouts, nil, logConfig)
 	suite.fs = kwfs
 }
 
@@ -60,7 +60,7 @@ func (suite *FsTestSuite) TestSpecialFileAttrs() {
 	}{
 		{"", 4096, 0755 | fuse.S_IFDIR},
 		{".version", len(fsVersion), 0444 | fuse.S_IFREG},
-		{".json/status", len(suite.fs.StatusJSON()), 0444 | fuse.S_IFREG},
+		{".json/status", len(suite.fs.statusJSON()), 0444 | fuse.S_IFREG},
 		{".running", -1, 0444 | fuse.S_IFREG},
 		{".clear_cache", 0, 0440 | fuse.S_IFREG},
 		{".json", 4096, 0700 | fuse.S_IFDIR},
@@ -156,7 +156,7 @@ func (suite *FsTestSuite) TestSpecialFileOpen() {
 
 	file, status = suite.fs.Open(".json/status", 0, fuseContext)
 	assert.Equal(fuse.OK, status)
-	assert.EqualValues(suite.fs.StatusJSON(), read(file))
+	assert.EqualValues(suite.fs.statusJSON(), read(file))
 
 	file, status = suite.fs.Open(".clear_cache", 0, fuseContext)
 	assert.Equal(fuse.OK, status)
@@ -241,6 +241,7 @@ func (suite *FsTestSuite) TestOpenDir() {
 		{
 			".json",
 			map[string]bool{
+				"metrics": true,
 				"status":  true,
 				"secret":  false,
 				"secrets": true,

--- a/glide.lock
+++ b/glide.lock
@@ -1,32 +1,21 @@
 hash: 3fb21e0e2d4062d0de91b07fa04212558ddb5b38e3511ee814ddb9e38bbe6907
-updated: 2016-03-06T19:30:29.304964851-08:00
+updated: 2016-03-22T22:28:35.131187911-07:00
 imports:
-- name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
-  subpackages:
-  - spew
 - name: github.com/hanwen/go-fuse
   version: 9ecf4dc59b43a0870562e61d7d9fc7d40e263ada
   subpackages:
   - fuse
   - fuse/nodefs
   - fuse/pathfs
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
+  - splice
 - name: github.com/rcrowley/go-metrics
   version: 51425a2415d21afadfd55cd93432c0bc69e9598d
 - name: github.com/square/go-sq-metrics
-  version: fee8afed8130469572261b06eb06a54eab2bb219
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
+  version: 6be866e8e88bf8fd368d6a2963179f0ac9aa6f15
 - name: github.com/stretchr/testify
   version: 1f4a1643a57e798696635ea4c126e9127adb7d3c
   subpackages:
   - assert
-  - http
-  - mock
 - name: golang.org/x/sys
   version: 50c6bc5e4292a1d4e65c6e9be5f53be28bcbe28e
   subpackages:

--- a/main.go
+++ b/main.go
@@ -106,7 +106,7 @@ func main() {
 	client := NewClient(*certFile, *keyFile, *caFile, serverURL, clientTimeout, logConfig)
 
 	ownership := NewOwnership(*asuser, *asgroup)
-	kwfs, root, err := NewKeywhizFs(&client, ownership, timeouts, logConfig)
+	kwfs, root, err := NewKeywhizFs(&client, ownership, timeouts, metricsHandle, logConfig)
 	if err != nil {
 		log.Fatalf("KeywhizFs init fail: %v\n", err)
 	}


### PR DESCRIPTION
Only does it if we're already submitting metrics.  Should we always collect metrics, even if we're not submitting?  Control with a flag?