### PR TITLE
Log when panicOnError() is called.

### DIFF
--- a/main.go
+++ b/main.go
@@ -160,6 +160,7 @@ func lockMemory() {
 // Helper function to panic on error
 func panicOnError(err error) {
 	if err != nil {
+		logger.Errorf("panic: %v", err)
 		panic(err)
 	}
 }


### PR DESCRIPTION
panic() logs the stacktrace to stderr. Have a trace of the event
in syslogs can be helpful.