### PR TITLE
Call os.Exit(1) on error.

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func main() {
 	kwfs, root, err := NewKeywhizFs(&client, ownership, timeouts, metricsHandle, logConfig)
 	if err != nil {
 		log.Fatalf("KeywhizFs init fail: %v\n", err)
+		os.Exit(1)
 	}
 
 	mountOptions := &fuse.MountOptions{
@@ -92,6 +93,7 @@ func main() {
 	server, err := fuse.NewServer(conn.RawFS(), *mountpoint, mountOptions)
 	if err != nil {
 		log.Fatalf("Mount fail: %v\n", err)
+		os.Exit(1)
 	}
 
 	// Catch SIGINT and exit cleanly.


### PR DESCRIPTION
Prevents nil pointer exceptions.