### PR TITLE
Fix readme run example and typos in docker_kwfs.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker build --rm -t keywhizfs .
 After building, you can run the newly built image by running:
 
 ```
-docker run --device /dev/fuse:/dev/fuse --cap-add=IPC_LOCK --cap-add=SYS_ADMIN keywhizfs --debug=true --ca=/go/src/github.com/square/keywhiz-fs/fixtures/cacert.crt --key=/go/src/github.com/square/keywhiz-fs/fixtures/client.pem https://localhost:443 /secrets/kwfs
+docker run --device /dev/fuse:/dev/fuse --cap-add=IPC_LOCK --cap-add=SYS_ADMIN keywhizfs --debug --ca=/go/src/github.com/square/keywhiz-fs/fixtures/cacert.crt --key=/go/src/github.com/square/keywhiz-fs/fixtures/client.pem https://localhost:443 /secrets/kwfs
 ```
 
 Note that we have to pass `--device /dev/fuse:/dev/fuse` to mount the fuse device into the container, and give `IPC_LOCK` and `SYS_ADMIN` capabilities to the container, so it can set `cap_ipc_lock` on the keywhiz-fs binary, and so it can mount fuse-fs filesystems, respectively.

--- a/docker_kwfs.sh
+++ b/docker_kwfs.sh
@@ -10,6 +10,6 @@ chown $KEYWHIZ_USER /dev/fuse
 chmod 640 /dev/fuse
 
 # This doesn't work with aufs. Need overlayFS to support it.
-setcap 'cap_ipc_lock=+ep' /go/bin/keywhizfs
+setcap 'cap_ipc_lock=+ep' /go/bin/keywhiz-fs
 
-sudo -u $KEYWHIZ_USER /go/bin/keywhizfs -asuser=$KEYWHIZ_USER -group=$KEYWHIZ_USER $@
+sudo -u $KEYWHIZ_USER /go/bin/keywhiz-fs --asuser=$KEYWHIZ_USER --group=$KEYWHIZ_USER $@


### PR DESCRIPTION
Trying to get the docker container example to run.  Ran into the issues described in https://github.com/square/keywhiz-fs/issues/63 