### PR TITLE
Update docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 sudo: required
 dist: trusty
 
-env:
-- GO15VENDOREXPERIMENT=1
+services:
+- docker
 
 go:
 - 1.6
@@ -21,6 +21,7 @@ before_install:
 
 install:
 - make build
+- docker build -t square/keywhiz-fs .
 
 script:
 - make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ FROM golang
 MAINTAINER Diogo Monica "diogo@docker.com"
 
 # Install sshfs and dependencies
-RUN apt-get update && apt-get install -y \
-    sshfs \
-    sudo \
-    --no-install-recommends
+RUN apt-get update && \
+    apt-get install -y sshfs sudo make git --no-install-recommends && \
+    go get github.com/Masterminds/glide
 
 # Add keywhiz user and group
 RUN useradd -ms /bin/false keywhiz
@@ -15,9 +14,11 @@ RUN useradd -ms /bin/false keywhiz
 COPY . /go/src/github.com/square/keywhiz-fs
 
 # Install keywhizfs
-RUN go get github.com/square/keywhiz-fs
+RUN cd /go/src/github.com/square/keywhiz-fs && \
+    glide install && \
+    go install .
 
 # Allows keywhiz-fs to expose its filesystems to other users besides the owner of the process
 RUN echo "user_allow_other" >> /etc/fuse.conf
 
-ENTRYPOINT ["/go/src/github.com/square/keywhiz-fs/docker_kwfs.sh"]
+ENTRYPOINT ["/go/src/github.com/square/keywhiz-fs/docker.sh"]

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Run `make build` to build a binary and `make test` to run tests.
 
 ## /etc/fuse.conf
 
-In order to allow keywhiz-fs to expose its filesystems to other users besides the owner of the process, fuse must be configured with the 'user_allow_other' option. Put the following snippet in `/etc/fuse.conf`.
+In order to allow KeywhizFs to expose its filesystems to other users besides the owner of the process, fuse must be configured with the 'user_allow_other' option. Put the following snippet in `/etc/fuse.conf`.
 
 ```
-# The following line was added by keywhiz-fs
+# The following line was added for keywhiz-fs
 user_allow_other
 ```
 
@@ -89,10 +89,10 @@ The `--cert` option may be omitted if the `--key` option contains both a PEM-enc
 
 ## Running in Docker
 
-We have included a Dockerfile so you can easily build and run keywhiz-fs with all of its dependencies. To build a kewhizfs Docker image run the following command:
+We have included a Dockerfile so you can easily build and run KeywhizFs with all of its dependencies. To build a kewhizfs Docker image run the following command:
 
 ```
-docker build --rm -t keywhizfs .
+docker build --rm -t square/keywhiz-fs .
 ```
 
 After building, you can run the newly built image by running:
@@ -101,21 +101,9 @@ After building, you can run the newly built image by running:
 docker run --device /dev/fuse:/dev/fuse --cap-add=IPC_LOCK --cap-add=SYS_ADMIN keywhizfs --debug --ca=/go/src/github.com/square/keywhiz-fs/fixtures/cacert.crt --key=/go/src/github.com/square/keywhiz-fs/fixtures/client.pem https://localhost:443 /secrets/kwfs
 ```
 
-Note that we have to pass `--device /dev/fuse:/dev/fuse` to mount the fuse device into the container, and give `IPC_LOCK` and `SYS_ADMIN` capabilities to the container, so it can set `cap_ipc_lock` on the keywhiz-fs binary, and so it can mount fuse-fs filesystems, respectively.
+Note that we have to pass `--device /dev/fuse:/dev/fuse` to mount the fuse device into the container, and give `SYS_ADMIN` capabilities to the container, so it can mount fuse-fs filesystems.
 
-This build mounts the fuseFS at `/secrets/kwfs/`.
-
-### Caveats
-
-Currently keywhiz-fs is not a [12 factor](http://12factor.net/) application, and it does not send unbuffered logs to stdout. It currently expects there to be a syslog server being ran locally.
-
-We can follow [this tutorial](https://jpetazzo.github.io/2014/08/24/syslog-docker/) and run syslogd in a separate container, allowing us to use an external container as our syslogd. After that, we can use the external container as our keywhiz-fs syslog server:
-
-```
-docker run -v /tmp/syslogdev/log:/dev/log --device /dev/fuse:/dev/fuse --cap-add=IPC_LOCK --cap-add=SYS_ADMIN keywhizfs --debug=true --ca=/go/src/github.com/square/keywhiz-fs/fixtures/cacert.crt --key=/go/src/github.com/square/keywhiz-fs/fixtures/client.pem https://localhost:443 /secrets/kwfs
-```
-
-Additionally, if you see the following error: `mlockall() failed with ENOMEM`, you are probably running your docker deamon with aufs, which does not support capability extensions, making `setcap 'cap_ipc_lock=+ep' /go/bin/keywhizfs` fail. You should use overlayFS instead.
+This build mounts the KeywhizFs filesystem at `/secrets/kwfs/`.
 
 # Contributing
 

--- a/docker.sh
+++ b/docker.sh
@@ -9,7 +9,4 @@ chown $KEYWHIZ_USER:$KEYWHIZ_USER $MOUNTPOINT
 chown $KEYWHIZ_USER /dev/fuse
 chmod 640 /dev/fuse
 
-# This doesn't work with aufs. Need overlayFS to support it.
-setcap 'cap_ipc_lock=+ep' /go/bin/keywhiz-fs
-
-sudo -u $KEYWHIZ_USER /go/bin/keywhiz-fs --asuser=$KEYWHIZ_USER --group=$KEYWHIZ_USER $@
+sudo -u $KEYWHIZ_USER /go/bin/keywhiz-fs --disable-mlock --asuser=$KEYWHIZ_USER --group=$KEYWHIZ_USER "$@"


### PR DESCRIPTION
r: @mcpherrinm @alokmenghrajani @worldwise001
Changes:
- Build docker container on travis-ci so we don't break it
- Use glide to build keywhiz-fs and pull in depends correctly
- Disable mlock in container so we can drop cap_lock_ipc
- Update readme to reflect changes
