### PR TITLE
Refactoring/improvements to cache/secretmap

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -221,21 +221,14 @@ func (c *Cache) backendSecretList() chan []Secret {
 
 		newMap := NewSecretMap(c.timeouts, c.now)
 		for _, backendSecret := range secrets {
-			if len(backendSecret.Content) == 0 {
-				// The backend didn't return any content. The cache might contain a secret with content, in
-				// which case we want to keep the cache's value (and not schedule it for delayed deletion).
-				if s, ok := c.secretMap.Get(backendSecret.Name); ok && len(s.Secret.Content) > 0 {
-					newMap.Put(backendSecret.Name, s.Secret)
-				} else {
-					// We don't have content for this secret. This happens when the cache has never seen a given secret
-					// (at startup or when a new secret is added).
-					// can happen.
-					newMap.Put(backendSecret.Name, backendSecret)
-				}
+			// The cache might contain a secret with content, in which case we want to keep the cache's
+			// value (and not schedule it for delayed deletion).
+			if s, ok := c.secretMap.Get(backendSecret.Name); ok && len(s.Secret.Content) > 0 {
+				newMap.Put(backendSecret.Name, s.Secret)
 			} else {
-				// TODO: explain why this case can happen. It doesn't seem like it can,
-				// listing secrets always returns just the names.
-				// Cache the latest info.
+				// We don't have content for this secret. This happens when the cache has never seen a given secret
+				// (at startup or when a new secret is added).
+				// can happen.
 				newMap.Put(backendSecret.Name, backendSecret)
 			}
 		}

--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"square/up/service/metrics"
 	"strings"
 	"time"
 
@@ -27,6 +26,7 @@ import (
 
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
+	"github.com/rcrowley/go-metrics"
 	"github.com/square/go-sq-metrics"
 	klog "github.com/square/keywhiz-fs/log"
 	"golang.org/x/sys/unix"

--- a/main.go
+++ b/main.go
@@ -19,16 +19,17 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"square/up/service/metrics"
 	"strings"
 	"time"
 
+	"gopkg.in/alecthomas/kingpin.v2"
+
 	"github.com/hanwen/go-fuse/fuse"
 	"github.com/hanwen/go-fuse/fuse/nodefs"
-	"github.com/rcrowley/go-metrics"
 	"github.com/square/go-sq-metrics"
 	klog "github.com/square/keywhiz-fs/log"
 	"golang.org/x/sys/unix"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 var (
@@ -70,6 +71,8 @@ func main() {
 		lockMemory()
 	}
 
+	// TODO: move time limit settings to config file?
+	// TODO: or at least make it consistent? some are set here, some are set above with app.Flag()
 	freshThreshold := *cacheTimeout
 	backendDeadline := 5 * time.Second
 	maxWait := *timeout + backendDeadline

--- a/secretmap.go
+++ b/secretmap.go
@@ -33,9 +33,10 @@ type SecretMap struct {
 // set a time to live. If the ttl value is 0, we keep the secret until it gets deleted
 // and its ttl changes.
 type SecretTime struct {
-	Secret Secret
-	Time   time.Time
-	ttl    time.Time
+	Secret  Secret
+	Time    time.Time
+	ttl     time.Time
+	deleted bool
 }
 
 // NewSecretMap initializes a new SecretMap.
@@ -62,7 +63,7 @@ func (m *SecretMap) Get(key string) (s SecretTime, ok bool) {
 	s, ok = m.m[key]
 	if ok && isExpired(s, m.getNow()) {
 		delete(m.m, key)
-		return SecretTime{}, false
+		return SecretTime{deleted: true}, false
 	}
 	return
 }
@@ -72,7 +73,7 @@ func (m *SecretMap) Put(key string, value Secret) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.m[key] = SecretTime{value, m.getNow(), time.Time{}}
+	m.m[key] = SecretTime{value, m.getNow(), time.Time{}, false}
 }
 
 // Schedules an entry for deletion.
@@ -91,6 +92,7 @@ func (m *SecretMap) Delete(key string) {
 
 // Schedules all values for deletion. Entries will be dropped if they aren't put back
 // before DeletionDelay elapses.
+// only used by tests
 func (m *SecretMap) DeleteAll() {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/secretmap.go
+++ b/secretmap.go
@@ -131,18 +131,18 @@ func (m *SecretMap) Replace(m2 *SecretMap) {
 }
 
 // Values returns a slice of stored secrets in no particular order.
-func (m *SecretMap) Values() []SecretTime {
+func (m *SecretMap) Values() []Secret {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	values := make([]SecretTime, len(m.m))
+	values := make([]Secret, len(m.m))
 	i := 0
 	now := m.getNow()
 	for key, value := range m.m {
 		if isExpired(value, now) {
 			delete(m.m, key)
 		} else {
-			values[i] = value
+			values[i] = value.Secret
 			i++
 		}
 	}

--- a/secretmap_test.go
+++ b/secretmap_test.go
@@ -41,7 +41,7 @@ func TestSecretMapOperations(t *testing.T) {
 
 	values := secretMap.Values()
 	assert.Len(values, 1)
-	assert.Equal(*s, values[0].Secret)
+	assert.Equal(*s, values[0])
 
 	lookup, ok = secretMap.Get("foo")
 	assert.True(ok)
@@ -59,7 +59,7 @@ func TestSecretMapOperations(t *testing.T) {
 	// Secret should still exist for a short amount of time
 	values = secretMap.Values()
 	assert.Len(values, 1)
-	assert.Equal(*s, values[0].Secret)
+	assert.Equal(*s, values[0])
 	// Advance current time by more than an hour, secret should now be gone
 	fake_now = fake_now.Add(2 * time.Hour)
 	values = secretMap.Values()


### PR DESCRIPTION
Some minor improvements and refactoring to cleanup unnecessary code. Also changed cache behavior so it treats a fresh cache entry for a deleted secret as a hit, rather than a miss (so it doesn't have to go to the backend).