### PR TITLE
Make files have Nlink = 1

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -324,6 +324,7 @@ func (kwfs KeywhizFs) secretAttr(s *Secret) *fuse.Attr {
 		Mtime: created,
 		Ctime: created,
 		Mode:  s.ModeValue(),
+		Nlink: 1,
 	}
 
 	attr.Uid = kwfs.Ownership.Uid
@@ -347,6 +348,7 @@ func (kwfs KeywhizFs) fileAttr(size uint64, mode uint32) *fuse.Attr {
 		Mtime: created,
 		Ctime: created,
 		Mode:  fuse.S_IFREG | mode,
+		Nlink: 1,
 	}
 	attr.Uid = kwfs.Ownership.Uid
 	attr.Gid = kwfs.Ownership.Gid


### PR DESCRIPTION
Having Nlink = 0 is wrong.  We don't support hardlinks in the
FS, so we can always write 1.  This isn't true of directories,
but we already handle those properly.

Fixes #74 