### PR TITLE
Stfinney/cache refresh fix

### DIFF
--- a/client.go
+++ b/client.go
@@ -178,9 +178,6 @@ func (c Client) RawSecret(name string) (data []byte, err error) {
 }
 
 // Secret returns an unmarshalled Secret struct after requesting a secret.
-// only used by tests
-// TODO: do we need this?
-// TODO: https://github.com/square/keywhiz-fs/issues/77
 func (c Client) Secret(name string) (secret *Secret, err error) {
 	data, err := c.RawSecret(name)
 	if err != nil {
@@ -228,9 +225,6 @@ func (c Client) RawSecretList() (data []byte, ok bool) {
 }
 
 // SecretList returns a slice of unmarshalled Secret structs after requesting a listing of secrets.
-// only used by tests
-// TODO: do we need this?
-// TODO: https://github.com/square/keywhiz-fs/issues/77
 func (c Client) SecretList() (secrets []Secret, ok bool) {
 	data, ok := c.RawSecretList()
 	if !ok {

--- a/secretmap.go
+++ b/secretmap.go
@@ -69,11 +69,14 @@ func (m *SecretMap) Get(key string) (s SecretTime, ok bool) {
 }
 
 // Put places a value in the map with a key, possibly overwriting an existing entry.
-func (m *SecretMap) Put(key string, value Secret) {
+func (m *SecretMap) Put(key string, value Secret, updated time.Time) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.m[key] = SecretTime{value, m.getNow(), time.Time{}, false}
+	if updated.Equal(time.Time{}) {
+		updated = m.getNow()
+	}
+	m.m[key] = SecretTime{value, updated, time.Time{}, false}
 }
 
 // Schedules an entry for deletion.

--- a/secretmap_test.go
+++ b/secretmap_test.go
@@ -36,7 +36,7 @@ func TestSecretMapOperations(t *testing.T) {
 	lookup, ok := secretMap.Get("foo")
 	assert.False(ok)
 
-	secretMap.Put("foo", *s)
+	secretMap.Put("foo", *s, time.Time{})
 	assert.Equal(1, secretMap.Len())
 
 	values := secretMap.Values()
@@ -47,14 +47,14 @@ func TestSecretMapOperations(t *testing.T) {
 	assert.True(ok)
 	assert.Equal(*s, lookup.Secret)
 
-	secretMap.Put("foo", Secret{})
+	secretMap.Put("foo", Secret{}, time.Time{})
 
 	lookup, ok = secretMap.Get("foo")
 	assert.True(ok)
 	assert.NotEqual(*s, lookup.Secret)
 
 	// Put a secret
-	secretMap.Put("foo", *s)
+	secretMap.Put("foo", *s, time.Time{})
 	secretMap.DeleteAll()
 	// Secret should still exist for a short amount of time
 	values = secretMap.Values()
@@ -70,13 +70,13 @@ func TestSecretMapTimestamp(t *testing.T) {
 	assert := assert.New(t)
 
 	secretMap := NewSecretMap(timeouts, nil)
-	secretMap.Put("foo", Secret{})
+	secretMap.Put("foo", Secret{}, time.Time{})
 
 	val, ok := secretMap.Get("foo")
 	assert.True(ok)
 	earlierTime := val.Time
 
-	secretMap.Put("foo", Secret{})
+	secretMap.Put("foo", Secret{}, time.Time{})
 	val, ok = secretMap.Get("foo")
 	assert.True(ok)
 	assert.True(val.Time.After(earlierTime))


### PR DESCRIPTION
Fixes bug where client.SecretList was refreshing the freshness times on cached secrets every time it pulled the list of secrets from the server. This led to the cached secrets rarely being considered "stale" when read, so mostly kwfs just returned secrets from cache rather than updating from the server. Also includes a test for the issue.

r: @worldwise001 @mcpherrinm @csstaub 